### PR TITLE
Add MCP2221A support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An [OctoPrint](http://octoprint.org/) plugin for filament motion sensor connecte
 Main updates - August 2024:
 - Removed RPi.GPIO requirements, replaced it with libgpiod.
 - Only one mode that uses both the distance and the timeout together.
+- Added optional support for MCP2221A USB GPIO adapters.
 
 ## Required sensor
 
@@ -44,7 +45,8 @@ After installation a restart of Octoprint is required.
 
 ### Installation Requirements
 - Python>3.8
-- [gpiod>=2.0.2](https://pypi.org/project/gpiod/) installed in Octoprint environment.
+- [gpiod>=2.0.2](https://pypi.org/project/gpiod/) installed in Octoprint environment for Raspberry Pi setups.
+- [PyMCP2221A](https://pypi.org/project/PyMCP2221A/) for USB MCP2221A adapters on other platforms.
 
 It has been tested with RPi5 running [octoprint_deploy 1.0.11](https://github.com/paukstelis/octoprint_deploy) and Zero2w running Octopi1.0 image. You are welcome to raise issues for untested environments.
 
@@ -53,6 +55,9 @@ It has been tested with RPi5 running [octoprint_deploy 1.0.11](https://github.co
 ### GPIO Pin
 * Choose any free GPIO pin you for data usage, but I would recommend to use GPIO pins without special functionalities like e.g. I2C
 * Run the sensor only on 3.3V, because GPIO pins don't like 5V for a long time
+
+### Interface Selection
+* Set the interface to `gpiod` for Raspberry Pi GPIO or `mcp2221` when using the USB adapter. `auto` will pick whichever is available.
 
 ### Pausing Limits
 A print can be paused due to two limits when the filament is not moving:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ To use this plugin a Filament Sensor needs to be sending a toggling digital sign
 * Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wiki/Plugin:-Plugin-Manager).
 * Manual install: Scroll down the "Get more" menu in Plugin Manager, Use this URL: https://github.com/tabahi/Octoprint-Smart-Filament-Sensor/archive/master.zip
 
+When installing from source you can include optional interfaces with pip extras, e.g.:
+
+```bash
+pip install "Octoprint-Filament-Motion-Sensor[gpiod]"
+pip install "Octoprint-Filament-Motion-Sensor[mcp2221]"
+```
+
 
 After installation a restart of Octoprint is required.
 

--- a/octoprint_filamentmotionsensor/SensorMCP2221Thread.py
+++ b/octoprint_filamentmotionsensor/SensorMCP2221Thread.py
@@ -1,0 +1,69 @@
+import threading
+import time
+
+try:
+    from PyMCP2221A import PyMCP2221A
+except Exception:  # pragma: no cover - optional dependency
+    PyMCP2221A = None
+
+
+# Helper used in __init__ to check if the MCP2221A device is available
+
+def plugin_check_mcp2221():
+    if PyMCP2221A is None:
+        return False
+    try:
+        dev = PyMCP2221A.PyMCP2221A()
+        dev.DetectDevice()
+        return True
+    except Exception:
+        return False
+
+
+class MotionSensorMCP2221Thread(threading.Thread):
+    """Monitor the motion sensor pin using an MCP2221A device."""
+
+    def __init__(self, threadID, threadName, pUsedPin, pMaxNotMovingTime, pLogger, pData, pCallback=None):
+        super().__init__()
+        self.threadID = threadID
+        self.name = threadName
+        self.callback = pCallback
+        self._logger = pLogger
+        self._data = pData
+        self.used_pin = pUsedPin
+        self.max_not_moving_time = pMaxNotMovingTime
+        self.keepRunning = True
+        self.device = None
+
+    def run(self):
+        if PyMCP2221A is None:
+            self._logger.error("PyMCP2221A library not available")
+            return
+        try:
+            self.device = PyMCP2221A.PyMCP2221A()
+            self.device.DetectDevice()
+            self.device.GPIO_Init()
+            # configure pin as input
+            self.device.GPIO_SetDirection(self.used_pin, 0)
+        except Exception as ex:  # pragma: no cover - hardware dependant
+            self._logger.error("Unable to initialise MCP2221", exc_info=ex)
+            return
+
+        last_val = self.device.GPIO_Read(self.used_pin)
+        self._data.last_motion_detected = time.time()
+
+        while self.keepRunning:
+            try:
+                val = self.device.GPIO_Read(self.used_pin)
+            except Exception as ex:  # pragma: no cover - hardware dependant
+                self._logger.error("Failed reading MCP2221", exc_info=ex)
+                break
+            if val != last_val:
+                last_val = val
+                self._data.last_motion_detected = time.time()
+                if self.callback:
+                    self.callback(bool(val))
+            if time.time() - self._data.last_motion_detected > self.max_not_moving_time:
+                if self.callback:
+                    self.callback(False)
+            time.sleep(0.01)

--- a/octoprint_filamentmotionsensor/SensorMCP2221Thread.py
+++ b/octoprint_filamentmotionsensor/SensorMCP2221Thread.py
@@ -7,17 +7,11 @@ except Exception:  # pragma: no cover - optional dependency
     PyMCP2221A = None
 
 
-# Helper used in __init__ to check if the MCP2221A device is available
+# Helper used by __plugin_check__ to verify the MCP2221A dependency
 
 def plugin_check_mcp2221():
-    if PyMCP2221A is None:
-        return False
-    try:
-        dev = PyMCP2221A.PyMCP2221A()
-        dev.DetectDevice()
-        return True
-    except Exception:
-        return False
+    """Return True if the PyMCP2221A library is available."""
+    return PyMCP2221A is not None
 
 
 class MotionSensorMCP2221Thread(threading.Thread):

--- a/octoprint_filamentmotionsensor/__init__.py
+++ b/octoprint_filamentmotionsensor/__init__.py
@@ -9,6 +9,12 @@ import time
 import flask
 from .SensorGPIOThread import MotionSensorGPIOThread
 from .SensorGPIOThread import plugin_check_rpi_gpio
+try:
+    from .SensorMCP2221Thread import MotionSensorMCP2221Thread, plugin_check_mcp2221
+except Exception:  # pragma: no cover - optional dependency might be missing
+    MotionSensorMCP2221Thread = None
+    def plugin_check_mcp2221():
+        return False
 from .data import FilamentMotionSensorDetectionData
 import os.path
 _debug_in_terminal = False # send debug messages in Gcode terminal
@@ -58,8 +64,9 @@ class FilamentMotionSensor(octoprint.plugin.StartupPlugin,
         self.t0_temp = -255
         self.last_temp_time = 0
         self.hook_it = True
-        
+
         self._data = FilamentMotionSensorDetectionData(self.motion_sensor_detection_distance, True, self.updateToUi)
+        self._sensor_interface = None
 #Properties
     @property
     def motion_sensor_pin(self):
@@ -72,6 +79,10 @@ class FilamentMotionSensor(octoprint.plugin.StartupPlugin,
     @property
     def detection_method(self):
         return int(self._settings.get(["detection_method"]))
+
+    @property
+    def sensor_interface(self):
+        return self._settings.get(["sensor_interface"])
 
     @property
     def motion_sensor_enabled(self):
@@ -120,7 +131,7 @@ class FilamentMotionSensor(octoprint.plugin.StartupPlugin,
 
 # Initialization methods
     def _setup_sensor(self):
-        
+
         self._logger.info("Using BCM Mode ONLY")
         
         if self.motion_sensor_enabled == False:
@@ -130,6 +141,13 @@ class FilamentMotionSensor(octoprint.plugin.StartupPlugin,
         self.motion_sensor_thread = None
 
         self.load_filament_sensor_data()
+        self._sensor_interface = None
+        if self.sensor_interface == "gpiod" or (self.sensor_interface == "auto" and plugin_check_rpi_gpio()):
+            self._sensor_interface = "gpiod"
+        elif self.sensor_interface == "mcp2221" or (self.sensor_interface == "auto" and plugin_check_mcp2221()):
+            self._sensor_interface = "mcp2221"
+        if self._sensor_interface is None:
+            self._logger.warning("No compatible GPIO interface detected")
 
 
     def load_filament_sensor_data(self):
@@ -138,6 +156,7 @@ class FilamentMotionSensor(octoprint.plugin.StartupPlugin,
     def on_after_startup(self):
         self._logger.info("Filament Motion Sensor started")
         self._setup_sensor()
+        self._logger.info("Sensor interface: %s" % (self._sensor_interface or "none"))
 
     def get_settings_defaults(self):
         return dict(
@@ -146,6 +165,7 @@ class FilamentMotionSensor(octoprint.plugin.StartupPlugin,
             motion_sensor_enabled = True, #Sensor detection is enabled by default
             motion_sensor_pin=-1,  # Default is no pin
             detection_method = 0, # 0 = timeout detection, 1 = distance detection
+            sensor_interface="auto",
 
             # Distance detection
             motion_sensor_detection_distance = 7, # Recommended detection distance from Marlin would be 7
@@ -195,8 +215,12 @@ class FilamentMotionSensor(octoprint.plugin.StartupPlugin,
         except: self.motion_sensor_thread  = None
         
         if(self.motion_sensor_thread is None):
-            self.motion_sensor_thread = MotionSensorGPIOThread(1, "ConnectionTest", self.motion_sensor_pin,
-                CONNECTION_TEST_TIME, self._logger, self._data, pCallback=self.connectionTestCallback)
+            if self._sensor_interface == "mcp2221" and MotionSensorMCP2221Thread:
+                self.motion_sensor_thread = MotionSensorMCP2221Thread(1, "ConnectionTest", self.motion_sensor_pin,
+                    CONNECTION_TEST_TIME, self._logger, self._data, pCallback=self.connectionTestCallback)
+            else:
+                self.motion_sensor_thread = MotionSensorGPIOThread(1, "ConnectionTest", self.motion_sensor_pin,
+                    CONNECTION_TEST_TIME, self._logger, self._data, pCallback=self.connectionTestCallback)
             self.motion_sensor_thread.start()
             self._data.connection_test_running = True
             self._logger.info("Connection test monitor started. Thread name:" + str(self.motion_sensor_thread.name ))
@@ -227,9 +251,12 @@ class FilamentMotionSensor(octoprint.plugin.StartupPlugin,
             if self.motion_sensor_thread == None:
                 self._logger.debug("Max Timeout: " + str(self.motion_sensor_max_not_moving))
 
-                
-                self.motion_sensor_thread = MotionSensorGPIOThread(1, "MotionSensorTimeoutDetectionThread", self.motion_sensor_pin,
-                    not_moving_return_seconds, self._logger, self._data, pCallback=self.sensor_event_callback)
+                if self._sensor_interface == "mcp2221" and MotionSensorMCP2221Thread:
+                    self.motion_sensor_thread = MotionSensorMCP2221Thread(1, "MotionSensorTimeoutDetectionThread", self.motion_sensor_pin,
+                        not_moving_return_seconds, self._logger, self._data, pCallback=self.sensor_event_callback)
+                else:
+                    self.motion_sensor_thread = MotionSensorGPIOThread(1, "MotionSensorTimeoutDetectionThread", self.motion_sensor_pin,
+                        not_moving_return_seconds, self._logger, self._data, pCallback=self.sensor_event_callback)
                 # Start Timeout_Detection thread
                 self.motion_sensor_thread.start()
                 
@@ -753,13 +780,12 @@ def __plugin_load__():
 def __plugin_check__():
     try:
         import gpiod
-    except ImportError:
-        return False
+        if plugin_check_rpi_gpio():
+            return True
+    except Exception:
+        pass
 
-    try:
-        if (plugin_check_rpi_gpio()==False): return False
-    except:
-        return False
+    if plugin_check_mcp2221():
+        return True
 
-
-    return True
+    return False

--- a/octoprint_filamentmotionsensor/__init__.py
+++ b/octoprint_filamentmotionsensor/__init__.py
@@ -7,8 +7,12 @@ from octoprint.events import Events
 #from datetime import datetime
 import time
 import flask
-from .SensorGPIOThread import MotionSensorGPIOThread
-from .SensorGPIOThread import plugin_check_rpi_gpio
+try:
+    from .SensorGPIOThread import MotionSensorGPIOThread, plugin_check_rpi_gpio
+except Exception:  # pragma: no cover - optional dependency might be missing
+    MotionSensorGPIOThread = None
+    def plugin_check_rpi_gpio():
+        return False
 try:
     from .SensorMCP2221Thread import MotionSensorMCP2221Thread, plugin_check_mcp2221
 except Exception:  # pragma: no cover - optional dependency might be missing
@@ -779,7 +783,6 @@ def __plugin_load__():
 
 def __plugin_check__():
     try:
-        import gpiod
         if plugin_check_rpi_gpio():
             return True
     except Exception:

--- a/octoprint_filamentmotionsensor/templates/filamentmotionsensor_settings.jinja2
+++ b/octoprint_filamentmotionsensor/templates/filamentmotionsensor_settings.jinja2
@@ -21,12 +21,23 @@
         <div class="control-group">
             <label class="control-label">{{ _('Motion Sensor GPIO Pin:') }}</label>
             <div class="controls" data-toggle="tooltip" title="{{ _('Which Raspberry Pi GPIO pin your switch is attached to (-1 disables the plugin)') }}">
-                <input type="text" step="any" min="0" class="input-mini text-right" data-bind="enable: enableCriticalSettings, value: settingsViewModel.settings.plugins.filamentmotionsensor.motion_sensor_pin"> 
+                <input type="text" step="any" min="0" class="input-mini text-right" data-bind="enable: enableCriticalSettings, value: settingsViewModel.settings.plugins.filamentmotionsensor.motion_sensor_pin">
             </div>
             
             <span class="help-block"><small>Refer to <a href="https://pinout.xyz/ ">pinout.xyz</a> for pinout. Use the BCM number after GPIO-?. e.g. GPIO 21 is the last pin. Prefer 17.</small></span>
             <button class="btn btn-primary span4" data-bind="enable: enableCriticalSettings, click: function() { showConnectionTest(); }" title="{{ _('Start sensor connection test')|edq }}">Test sensor</button>
             
+        </div>
+
+        <div class="control-group">
+            <label class="control-label">{{ _('Sensor Interface:') }}</label>
+            <div class="controls" data-toggle="tooltip" title="{{ _('Select GPIO library. Auto chooses gpiod or MCP2221 if available.') }}">
+                <select class="select-mini" data-bind="value: settingsViewModel.settings.plugins.filamentmotionsensor.sensor_interface">
+                    <option value="auto">auto</option>
+                    <option value="gpiod">gpiod</option>
+                    <option value="mcp2221">mcp2221</option>
+                </select>
+            </div>
         </div>
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,13 @@ plugin_url = "https://github.com/tabahi/Octoprint-Filament-Motion-Sensor"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ['gpiod>=2.0.2', 'PyMCP2221A>=0.5.0']
+plugin_requires = []
+
+# Optional interfaces
+plugin_extras = {
+    'gpiod': ['gpiod>=2.0.2'],
+    'mcp2221': ['PyMCP2221A>=0.5.0'],
+}
 
 # --------------------------------------------------------------------------------------------------------------------
 # More advanced options that you usually shouldn't have to touch follow after this point
@@ -58,7 +64,9 @@ plugin_ignored_packages = []
 # Example:
 #     plugin_requires = ["someDependency==dev"]
 #     additional_setup_parameters = {"dependency_links": ["https://github.com/someUser/someRepo/archive/master.zip#egg=someDependency-dev"]}
-additional_setup_parameters = {}
+additional_setup_parameters = {
+    'extras_require': plugin_extras,
+}
 
 ########################################################################################################################
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ plugin_url = "https://github.com/tabahi/Octoprint-Filament-Motion-Sensor"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ['gpiod>=2.0.2']
+plugin_requires = ['gpiod>=2.0.2', 'PyMCP2221A>=0.5.0']
 
 # --------------------------------------------------------------------------------------------------------------------
 # More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
## Summary
- add optional dependency on `PyMCP2221A`
- implement `SensorMCP2221Thread` for USB MCP2221A devices
- select GPIO backend via new `sensor_interface` option
- update plugin logic and settings template
- document MCP2221A support in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687260c687d0832a8ee2842a3b79a941